### PR TITLE
Add rails7-samson-sample-client as sub module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "rails7-samson-sample-client"]
+	path = rails7-samson-sample-client
+	url = git@github.com:publichtml/rails7-samson-sample-client.git

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
+# samson-sample
+
+[Samson](https://github.com/zendesk/samson) を理解するために、サンプルのクライアントと接続してデプロイを試せるようにしたもの。
+
+サンプルクライアントは [rails7-samson-sample-client](https://github.com/publichtml/rails7-samson-sample-client) にあり、Welcome と表示するだけの Rails アプリ。
+
+## Usage
+
+```
+$ git clone --recursive git@github.com:publichtml/samson-sample.git
+
+$ cd samson-sample
+
+$ docker-compose -f docker-compose.with_sample_client.yml build
+$ docker-compose -f docker-compose.with_sample_client.yml up -d
+```
+
+- http://localhost:3000 にアクセスすると Samson が使える
+- `Produciton` state でデプロイ実行
+- http://localhost:4000 でデプロイされたサンプルアプリが動いている
+  - `Welcome` とだけ表示される
+
+# Original README
+
 <img src="https://github.com/zendesk/samson/raw/master/app/assets/images/logo_light.png" width=400/>
 
 ![Build status](https://github.com/zendesk/samson/workflows/repo-checks/badge.svg)

--- a/docker-compose.with_sample_client.yml
+++ b/docker-compose.with_sample_client.yml
@@ -1,0 +1,20 @@
+version: "2"
+services:
+  samson:
+    image: zendesk/samson:latest # replace with `build: .` to use Dockerfile (--build to rebuild it)
+    ports:
+      - "3000:9080"
+    volumes:
+      - .:/app/
+    environment:
+      DATABASE_URL: "sqlite3:///app/db/development.sqlite3"
+      RAILS_LOG_TO_STDOUT: 1
+    command: ["./script/docker_dev_server"]
+
+  app:
+    build: rails7-samson-sample-client/
+    ports:
+      - "4000:3000"
+      - "4022:22"
+    privileged: true
+    tty: true

--- a/docker-compose.with_sample_client.yml
+++ b/docker-compose.with_sample_client.yml
@@ -4,6 +4,7 @@ services:
     image: zendesk/samson:latest # replace with `build: .` to use Dockerfile (--build to rebuild it)
     ports:
       - "3000:9080"
+    platform: linux/x86_64
     volumes:
       - .:/app/
     environment:

--- a/script/docker_dev_server
+++ b/script/docker_dev_server
@@ -12,7 +12,7 @@ if [ -f db/development.sqlite3 ]; then
     RAILS_DUMP_SCHEMA=false bundle exec rake db:migrate
 else
     # NOTE: db:setup fails when schema is not up to date, so we need to do the create+load instead
-    RAILS_DUMP_SCHEMA=false bundle exec rake db:create db:schema:load db:migrate
+    RAILS_DUMP_SCHEMA=false bundle exec rake db:create db:schema:load db:migrate db:seed
 fi
 
 exec bundle exec puma -C config/puma.rb


### PR DESCRIPTION
https://github.com/publichtml/rails7-samson-sample-client で作った sample client と接続できるようにした。
操作方法は README の冒頭を参照。

- sample client は sub module として取り込み、 `docker-compose` で samson 自身と sample client 双方を起動できるようにした
  - docker-compose.with_sample_client.yml を使用
- sample client へのデプロイに必要なデータは seed で仕込んでいる
